### PR TITLE
[PR] Checkout required test data with other upstream tests

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -79,6 +79,7 @@ install_test_suite() {
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
 		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
 
 	cd $WP_TESTS_DIR


### PR DESCRIPTION
An error will show if this data is not available, even though the tests still run fine.

See https://github.com/wp-cli/wp-cli/pull/3571