### PR TITLE
[PR] Update PHPCS (2.8.x) and WPCS (0.11.0) versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     }
   ],
   "require-dev": {
-    "squizlabs/php_codesniffer": "2.7.x",
-    "wp-coding-standards/wpcs": "0.10.0"
+    "squizlabs/php_codesniffer": "2.8.x",
+    "wp-coding-standards/wpcs": "0.11.0"
   },
   "scripts": {
     "post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths vendor/wp-coding-standards/wpcs",


### PR DESCRIPTION
See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/0.11.0